### PR TITLE
Do not fail when the destination file doesn't exist yet / Output success message

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     }
   ],
   "dependencies": {
+    "chalk": "^0.5.0",
     "image-size": ""
   }
 }

--- a/tasks/image_size.js
+++ b/tasks/image_size.js
@@ -9,6 +9,7 @@
 
 module.exports = function(grunt) {
 	var path = require('path');
+	var chalk = require('chalk');
 	var sizer = require('image-size');
 	var types = [
 		'.png',
@@ -51,6 +52,7 @@ module.exports = function(grunt) {
 
 			if (file.dest) {
 				grunt.file.write(file.dest, JSON.stringify(output));
+				grunt.log.writeln('File ' + chalk.cyan(file.dest) + ' created.');
 			}
 		});
 	});


### PR DESCRIPTION
- Curretly this plugin fails when the destination JSON file doesn't exist yet. so I fixed this problem by removing [`grunt.file.isFile`](http://gruntjs.com/api/grunt.file#grunt.file.isfile).
- I added the success message of file output. All grunt-contrib plugins and many third-party plugins output the message when they create files to the destination.
